### PR TITLE
mount /sdcard/

### DIFF
--- a/src/service/plugins/sftp.js
+++ b/src/service/plugins/sftp.js
@@ -222,7 +222,7 @@ const SFTPPlugin = GObject.registerClass({
 
             // This is the actual call to mount the device
             const host = this.device.channel.host;
-            const uri = `sftp://${host}:${packet.body.port}/`;
+            const uri = `sftp://${host}:${packet.body.port}/sdcard/`;
             const file = Gio.File.new_for_uri(uri);
 
             await file.mount_enclosing_volume(GLib.PRIORITY_DEFAULT, op,


### PR DESCRIPTION
android apps without root access can only access /sdcard/ 
also only works with the "MANAGE_EXTERNAL_STORAGE" permission granted

otherwise this error appears: 
![image](https://github.com/lollilol/gnome-shell-extension-gsconnect/assets/38194372/50b66f80-8132-4232-b970-560e95f8f49b)

after appending /sdcard/ to the sftp uri, i was able to successfully connect:
![image](https://github.com/lollilol/gnome-shell-extension-gsconnect/assets/38194372/9202a6ec-349b-4eb2-9cd0-524096e40f69)
